### PR TITLE
Have floats near zero converge to 0.000001

### DIFF
--- a/src/Shrink.elm
+++ b/src/Shrink.elm
@@ -459,7 +459,10 @@ seriesInt low high =
 seriesFloat : Float -> Float -> LazyList Float
 seriesFloat low high =
     if low >= high - 0.0001 then
-        empty
+        if high /= 0.000001 then
+            Lazy.List.singleton (low + 0.000001)
+        else
+            empty
     else
         let
             low' =


### PR DESCRIPTION
If you have a fuzz test that fails for all positive or all negative floats, shrinking will produce one answer instead of many small floats.

This value was chosen because it is the largest positive float not to be `toString`-ed into scientific notation.

My concern is that this feels like special casing, because if your test fails with values greater than 1, it will not converge onto 1.000001. Also, I just realized that this shrinker will never produce `0` exactly.

@rtfeldman, what do you think?
